### PR TITLE
Use only relative imports in aiter core

### DIFF
--- a/aiter/event_stream.py
+++ b/aiter/event_stream.py
@@ -1,4 +1,5 @@
-from aiter import map_aiter, join_aiters
+from .map_aiter import map_aiter
+from .join_aiters import join_aiters
 
 
 def message_stream_to_event_stream(event_template, message_stream):

--- a/aiter/server.py
+++ b/aiter/server.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from aiter import push_aiter
+from .push_aiter import push_aiter
 
 
 async def aiter_server(start_f, *args, **kwargs):


### PR DESCRIPTION
Having only relative imports allows aiter to be used without
installation.